### PR TITLE
added biopython

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -8,3 +8,4 @@ dependencies:
         - mamba
         - pandas
         - pyyaml
+        - biopython


### PR DESCRIPTION
see #71 :) @akrinos 

It appears that `12-MAD.smk` rule requires Bio but it isn't currently included in the environment build. 